### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 Flask
+flask_cors
 requests
 beautifulsoup4
 pandas
-sqlite3
-json
 langdetect
 pysocks
 openai


### PR DESCRIPTION
You've included sqlite3 and json in the requirements.txt. Those are standard libraries in python and don't need installing. This throws an error when trying to run pip install -r requirements.txt. You'd better remove those libraries to make your repo more accessible.

Also, the following requirement was not satisfied: flask_cors.