### PR TITLE
updated requirements to work from cold start

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@ Flask
 requests
 beautifulsoup4
 pandas
-sqlite3
-json
 langdetect
 pysocks
 openai
 pdfminer.six
+flask_cors


### PR DESCRIPTION
I started using this repo from a cold start on my machine. 
As per PR #3 two repos need to be removed as they will cause an error when running ``` pip install -r requirements.txt```
Additionally, the repo ```flask_cors``` needs to be included to be able to run ```python app.py```